### PR TITLE
CSPG-69336,CSPG-68232,CSPG-69313: Fix multiple issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The Bicep templates perform the following actions:
    - [US-1](https://falcon.crowdstrike.com/cloud-security/registration-v2/azure)
    - [US-2](https://falcon.us-2.crowdstrike.com/cloud-security/registration-v2/azure)
    - [EU-1](https://falcon.eu-1.crowdstrike.com/cloud-security/registration-v2/azure)
-2. Ensure you have a CrowdStrike API URL, client ID, and client secret for Falcon Cloud Security with the CSPM Registration Read and Write scopes. If you don't already have API credentials, you can set them up in the Falcon console. You must be a Falcon Administrator to access the API clients page:
+2. Ensure you have a CrowdStrike API URL, client ID, and client secret for Falcon Cloud Security with `Cloud security Azure registration (Write)` scope. If you don't already have API credentials, you can set them up in the Falcon console. You must be a Falcon Administrator to access the API clients page:
    - [US-1](https://falcon.crowdstrike.com/api-clients-and-keys/)
    - [US-2](https://falcon.us-2.crowdstrike.com/api-clients-and-keys/)
    - [EU-1](https://falcon.eu-1.crowdstrike.com/api-clients-and-keys/clients)

--- a/cs-deployment-management-group.bicep
+++ b/cs-deployment-management-group.bicep
@@ -160,7 +160,7 @@ module deploymentScope 'modules/cs-deployment-scope-mg.bicep' = if (shouldDeploy
     managementGroupIds: managementGroups
     subscriptionIds: subscriptions
     resourceGroupName: resourceGroupName
-    scriptRunnerIdentityId: scriptRunnerIdentity.outputs.id
+    scriptRunnerIdentityId: scriptRunnerIdentity!.outputs.id
     csInfraSubscriptionId: csInfraSubscriptionId
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
@@ -174,7 +174,7 @@ module logIngestion 'modules/cs-log-ingestion-mg.bicep' = if (shouldDeployLogIng
   name: '${resourceNamePrefix}cs-log-mg-deployment${environment}${resourceNameSuffix}'
   params: {
     managementGroupIds: managementGroups
-    subscriptionIds: deploymentScope.outputs.allSubscriptions
+    subscriptionIds: deploymentScope!.outputs.allSubscriptions
     csInfraSubscriptionId: csInfraSubscriptionId
     resourceGroupName: resourceGroupName
     activityLogSettings: logIngestionSettings.?activityLogSettings ?? {
@@ -204,10 +204,10 @@ module updateRegistration 'modules/cs-update-registration-rg.bicep' = if (should
     falconApiFqdn: falconApiFqdn
     falconClientId: validatedFalconClientID
     falconClientSecret: validatedFalconClientSecret
-    activityLogEventHubId: logIngestion.outputs.activityLogEventHubId
-    activityLogEventHubConsumerGroupName: logIngestion.outputs.activityLogEventHubConsumerGroupName
-    entraLogEventHubId: logIngestion.outputs.entraLogEventHubId
-    entraLogEventHubConsumerGroupName: logIngestion.outputs.entraLogEventHubConsumerGroupName
+    activityLogEventHubId: logIngestion!.outputs.activityLogEventHubId
+    activityLogEventHubConsumerGroupName: logIngestion!.outputs.activityLogEventHubConsumerGroupName
+    entraLogEventHubId: logIngestion!.outputs.entraLogEventHubId
+    entraLogEventHubConsumerGroupName: logIngestion!.outputs.entraLogEventHubConsumerGroupName
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
     env: env
@@ -218,11 +218,11 @@ module updateRegistration 'modules/cs-update-registration-rg.bicep' = if (should
 
 output customReaderRoleNameForSubs array = assetInventory.outputs.customRoleNameForSubs
 output customReaderRoleNameForMGs array = assetInventory.outputs.customRoleNameForMGs
-output activityLogEventHubId string = shouldDeployLogIngestion ? logIngestion.outputs.activityLogEventHubId : ''
+output activityLogEventHubId string = shouldDeployLogIngestion ? logIngestion!.outputs.activityLogEventHubId : ''
 output activityLogEventHubConsumerGroupName string = shouldDeployLogIngestion
-  ? logIngestion.outputs.activityLogEventHubConsumerGroupName
+  ? logIngestion!.outputs.activityLogEventHubConsumerGroupName
   : ''
-output entraLogEventHubId string = shouldDeployLogIngestion ? logIngestion.outputs.entraLogEventHubId : ''
+output entraLogEventHubId string = shouldDeployLogIngestion ? logIngestion!.outputs.entraLogEventHubId : ''
 output entraLogEventHubConsumerGroupName string = shouldDeployLogIngestion
-  ? logIngestion.outputs.entraLogEventHubConsumerGroupName
+  ? logIngestion!.outputs.entraLogEventHubConsumerGroupName
   : ''

--- a/cs-deployment-management-group.bicep
+++ b/cs-deployment-management-group.bicep
@@ -36,7 +36,7 @@ param falconClientId string = ''
 @secure()
 param falconClientSecret string = ''
 
-@description('List of IP addresses of Crowdstrike Falcon service. For the IP address list for your Falcon region, refer to https://falcon.crowdstrike.com/documentation/page/re07d589/add-crowdstrike-ip-addresses-to-cloud-provider-allowlists-0.')
+@description('List of IP addresses of CrowdStrike Falcon service. For the IP address list for your Falcon region, refer to https://falcon.crowdstrike.com/documentation/page/re07d589/add-crowdstrike-ip-addresses-to-cloud-provider-allowlists-0.')
 param falconIpAddresses array = []
 
 @description('Indicates whether this is the initial registration')
@@ -51,7 +51,7 @@ param env string = 'prod'
 
 @description('Tags to be applied to all deployed resources. Used for resource organization and governance.')
 param tags object = {
-  CSTagVendor: 'Crowdstrike'
+  CSTagVendor: 'CrowdStrike'
 }
 
 @maxLength(10)
@@ -114,7 +114,7 @@ var validatedResourceNameSuffix = length(resourceNamePrefix) + length(resourceNa
   : resourceNameSuffix
 
 /* Resources used across modules
-1. Role assignments to the Crowdstrike's app service principal
+1. Role assignments to the CrowdStrike's app service principal
 2. Discover subscriptions of the specified management groups
 */
 module assetInventory 'modules/cs-asset-inventory-mg.bicep' = {

--- a/cs-deployment-subscription.bicep
+++ b/cs-deployment-subscription.bicep
@@ -155,10 +155,10 @@ module updateRegistration 'modules/cs-update-registration-rg.bicep' = if (should
     falconApiFqdn: falconApiFqdn
     falconClientId: validatedFalconClientID
     falconClientSecret: validatedFalconClientSecret
-    activityLogEventHubId: logIngestion.outputs.activityLogEventHubId
-    activityLogEventHubConsumerGroupName: logIngestion.outputs.activityLogEventHubConsumerGroupName
-    entraLogEventHubId: logIngestion.outputs.entraLogEventHubId
-    entraLogEventHubConsumerGroupName: logIngestion.outputs.entraLogEventHubConsumerGroupName
+    activityLogEventHubId: logIngestion!.outputs.activityLogEventHubId
+    activityLogEventHubConsumerGroupName: logIngestion!.outputs.activityLogEventHubConsumerGroupName
+    entraLogEventHubId: logIngestion!.outputs.entraLogEventHubId
+    entraLogEventHubConsumerGroupName: logIngestion!.outputs.entraLogEventHubConsumerGroupName
     resourceNamePrefix: resourceNamePrefix
     resourceNameSuffix: resourceNameSuffix
     env: env
@@ -168,11 +168,11 @@ module updateRegistration 'modules/cs-update-registration-rg.bicep' = if (should
 }
 
 output customRoleNameForSubs array = assetInventory.outputs.customRoleNameForSubs
-output activityLogEventHubId string = shouldDeployLogIngestion ? logIngestion.outputs.activityLogEventHubId : ''
+output activityLogEventHubId string = shouldDeployLogIngestion ? logIngestion!.outputs.activityLogEventHubId : ''
 output activityLogEventHubConsumerGroupName string = shouldDeployLogIngestion
-  ? logIngestion.outputs.activityLogEventHubConsumerGroupName
+  ? logIngestion!.outputs.activityLogEventHubConsumerGroupName
   : ''
-output entraLogEventHubId string = shouldDeployLogIngestion ? logIngestion.outputs.entraLogEventHubId : ''
+output entraLogEventHubId string = shouldDeployLogIngestion ? logIngestion!.outputs.entraLogEventHubId : ''
 output entraLogEventHubConsumerGroupName string = shouldDeployLogIngestion
-  ? logIngestion.outputs.entraLogEventHubConsumerGroupName
+  ? logIngestion!.outputs.entraLogEventHubConsumerGroupName
   : ''

--- a/cs-deployment-subscription.bicep
+++ b/cs-deployment-subscription.bicep
@@ -29,7 +29,7 @@ param falconClientId string = ''
 @secure()
 param falconClientSecret string = ''
 
-@description('List of IP addresses of Crowdstrike Falcon service. For the IP address list for your Falcon region, refer to https://falcon.crowdstrike.com/documentation/page/re07d589/add-crowdstrike-ip-addresses-to-cloud-provider-allowlists-0.')
+@description('List of IP addresses of CrowdStrike Falcon service. For the IP address list for your Falcon region, refer to https://falcon.crowdstrike.com/documentation/page/re07d589/add-crowdstrike-ip-addresses-to-cloud-provider-allowlists-0.')
 param falconIpAddresses array = []
 
 @description('Principal ID of the CrowdStrike application registered in Entra ID. This ID is used for role assignments and access control.')
@@ -46,12 +46,14 @@ param env string = 'prod'
 
 @description('Tags to be applied to all deployed resources. Used for resource organization and governance.')
 param tags object = {
-  CSTagVendor: 'crowdstrike'
+  CSTagVendor: 'CrowdStrike'
 }
 
+@maxLength(10)
 @description('Optional prefix added to all resource names for organization and identification purposes.')
 param resourceNamePrefix string = ''
 
+@maxLength(10)
 @description('Optional suffix added to all resource names for organization and identification purposes.')
 param resourceNameSuffix string = ''
 
@@ -103,7 +105,7 @@ var validatedResourceNameSuffix = length(resourceNamePrefix) + length(resourceNa
   : resourceNameSuffix
 
 /* Resources used across modules
-1. Role assignments to the Crowdstrike's app service principal
+1. Role assignments to the CrowdStrike's app service principal
 */
 module assetInventory 'modules/cs-asset-inventory-sub.bicep' = {
   name: '${validatedResourceNamePrefix}cs-inv-sub-deployment${environment}${validatedResourceNameSuffix}'

--- a/modules/cs-log-ingestion-sub.bicep
+++ b/modules/cs-log-ingestion-sub.bicep
@@ -37,7 +37,7 @@ param activityLogSettings ActivityLogSettings
 @description('Configuration settings for Microsoft Entra ID log collection and monitoring.')
 param entraIdLogSettings EntraIdLogSettings
 
-@description('List of IP addresses of Crowdstrike Falcon service. Please refer to https://falcon.crowdstrike.com/documentation/page/re07d589/add-crowdstrike-ip-addresses-to-cloud-provider-allowlists-0 for the IP address list of your Falcon region.')
+@description('List of IP addresses of CrowdStrike Falcon service. Please refer to https://falcon.crowdstrike.com/documentation/page/re07d589/add-crowdstrike-ip-addresses-to-cloud-provider-allowlists-0 for the IP address list of your Falcon region.')
 param falconIpAddresses array
 
 @description('List of Azure subscription IDs to monitor. These subscriptions will be configured for CrowdStrike monitoring.')

--- a/modules/log-ingestion/eventHub.bicep
+++ b/modules/log-ingestion/eventHub.bicep
@@ -181,7 +181,7 @@ module existingActivityLogEventHubRoleAssignment 'eventHubRoleAssignment.bicep' 
   }
 }
 
-module existingEntraLogEventHubRoleAssignment 'eventHubRoleAssignment.bicep' = if (shouldUseExistingEventHubForEntraLog && existingEntraLogEventHubSettings.resourceGroup != existingActivityLogEventHubSettings.resourceGroup && existingEntraLogEventHubSettings.subscriptionId != existingActivityLogEventHubSettings.subscriptionId) {
+module existingEntraLogEventHubRoleAssignment 'eventHubRoleAssignment.bicep' = if (shouldUseExistingEventHubForEntraLog && existingEntraLogEventHubSettings.resourceGroup != existingActivityLogEventHubSettings.resourceGroup) {
   name: guid(azurePrincipalId, eventHubsDataReceiverRole, entraLogEventHub.id)
   scope: az.resourceGroup(
     existingEntraLogEventHubSettings.subscriptionId,

--- a/modules/log-ingestion/eventHub.bicep
+++ b/modules/log-ingestion/eventHub.bicep
@@ -171,7 +171,7 @@ module eventHubRoleAssignment 'eventHubRoleAssignment.bicep' = if (shouldDeployE
 }
 
 module existingActivityLogEventHubRoleAssignment 'eventHubRoleAssignment.bicep' = if (shouldUseExistingEventHubForActivityLog) {
-  name: guid(azurePrincipalId, eventHubsDataReceiverRole, activityLogEventHub.id)
+  name: guid(azurePrincipalId, eventHubsDataReceiverRole, existingActivityLogEventHub.id)
   scope: az.resourceGroup(
     existingActivityLogEventHubSettings.subscriptionId,
     existingActivityLogEventHubSettings.resourceGroup
@@ -184,7 +184,7 @@ module existingActivityLogEventHubRoleAssignment 'eventHubRoleAssignment.bicep' 
 }
 
 module existingEntraLogEventHubRoleAssignment 'eventHubRoleAssignment.bicep' = if (shouldUseExistingEventHubForEntraLog && (existingEntraLogEventHubSettings.subscriptionId != existingActivityLogEventHubSettings.subscriptionId || existingEntraLogEventHubSettings.resourceGroup != existingActivityLogEventHubSettings.resourceGroup)) {
-  name: guid(azurePrincipalId, eventHubsDataReceiverRole, entraLogEventHub.id)
+  name: guid(azurePrincipalId, eventHubsDataReceiverRole, existingEntraLogEventHub.id)
   scope: az.resourceGroup(
     existingEntraLogEventHubSettings.subscriptionId,
     existingEntraLogEventHubSettings.resourceGroup

--- a/modules/log-ingestion/eventHub.bicep
+++ b/modules/log-ingestion/eventHub.bicep
@@ -80,7 +80,7 @@ resource eventHubNamespace 'Microsoft.EventHub/namespaces@2024-01-01' = if (shou
   }
 }
 
-// Allow Crowdstrike Falcon to access the Eventhub
+// Allow CrowdStrike Falcon to access the Eventhub
 resource eventHubNamespaceNetworkRuleSet 'Microsoft.EventHub/namespaces/networkRuleSets@2024-01-01' = if (shouldDeployEventHubNamespace) {
   name: 'default' // This is fixed
   parent: eventHubNamespace

--- a/modules/log-ingestion/eventHub.bicep
+++ b/modules/log-ingestion/eventHub.bicep
@@ -56,6 +56,8 @@ var existingEntraLogEventHubSettings = {
   namespace: entraLogSettings.?existingEventhub.?namespaceName ?? ''
   name: entraLogSettings.?existingEventhub.?name ?? ''
 }
+
+// Event Hub namespace is globally unique
 var isSameExistingEventHubNamespace = shouldUseExistingEventHubForActivityLog && shouldUseExistingEventHubForEntraLog && existingActivityLogEventHubSettings.namespace == existingEntraLogEventHubSettings.namespace
 var isSameExistingEventHub = isSameExistingEventHubNamespace && existingActivityLogEventHubSettings.name == existingEntraLogEventHubSettings.name
 
@@ -181,7 +183,7 @@ module existingActivityLogEventHubRoleAssignment 'eventHubRoleAssignment.bicep' 
   }
 }
 
-module existingEntraLogEventHubRoleAssignment 'eventHubRoleAssignment.bicep' = if (shouldUseExistingEventHubForEntraLog && existingEntraLogEventHubSettings.resourceGroup != existingActivityLogEventHubSettings.resourceGroup) {
+module existingEntraLogEventHubRoleAssignment 'eventHubRoleAssignment.bicep' = if (shouldUseExistingEventHubForEntraLog && (existingEntraLogEventHubSettings.subscriptionId != existingActivityLogEventHubSettings.subscriptionId || existingEntraLogEventHubSettings.resourceGroup != existingActivityLogEventHubSettings.resourceGroup)) {
   name: guid(azurePrincipalId, eventHubsDataReceiverRole, entraLogEventHub.id)
   scope: az.resourceGroup(
     existingEntraLogEventHubSettings.subscriptionId,

--- a/modules/log-ingestion/logIngestionForMgmtGroup.bicep
+++ b/modules/log-ingestion/logIngestionForMgmtGroup.bicep
@@ -1,4 +1,4 @@
-import { ActivityLogSettings, EntraIdLogSettings } from '../../models/log-ingestion.bicep'
+import { ActivityLogSettings } from '../../models/log-ingestion.bicep'
 
 targetScope = 'managementGroup'
 

--- a/modules/log-ingestion/logIngestionForSub.bicep
+++ b/modules/log-ingestion/logIngestionForSub.bicep
@@ -36,7 +36,7 @@ param activityLogSettings ActivityLogSettings
 @description('Configuration settings for Microsoft Entra ID log collection and monitoring.')
 param entraIdLogSettings EntraIdLogSettings
 
-@description('List of IP addresses of Crowdstrike Falcon service. Please refer to https://falcon.crowdstrike.com/documentation/page/re07d589/add-crowdstrike-ip-addresses-to-cloud-provider-allowlists-0 for the IP address list of your Falcon region.')
+@description('List of IP addresses of CrowdStrike Falcon service. Please refer to https://falcon.crowdstrike.com/documentation/page/re07d589/add-crowdstrike-ip-addresses-to-cloud-provider-allowlists-0 for the IP address list of your Falcon region.')
 param falconIpAddresses array
 
 @description('List of Azure subscription IDs to monitor. These subscriptions will be configured for CrowdStrike monitoring.')

--- a/scripts/Update-Registration.ps1
+++ b/scripts/Update-Registration.ps1
@@ -80,7 +80,7 @@ function Set-AzureEventHubsInfo {
         Write-Output "Update registration. Url: $($Params.Uri)"
         Write-Output "Update registration. Request body: $($Params.Body)"
         $response = Invoke-WebRequest @Params
-        Write-Output "Update registration sucess. Response: $($response.Content)`n"
+        Write-Output "Update registration success. Response: $($response.Content)`n"
     }
     catch [System.Exception] { 
         Write-Error "An exception was caught: $($_.Exception.Message), $($_.ErrorDetails.Message)"

--- a/scripts/Update-Registration.ps1
+++ b/scripts/Update-Registration.ps1
@@ -1,5 +1,5 @@
 ## CrowdStrike API Client Scopes required:
-## - CSPM Registration (read/write)
+## - Cloud security Azure registration (Write)
 using namespace System.Runtime.Serialization
 
 param (


### PR DESCRIPTION
# JIRA
- https://jira.cs.sys/browse/CSPG-69336
- https://jira.cs.sys/browse/CSPG-68232
- https://jira.cs.sys/browse/CSPG-69313

# Description

1. Fix deployment failed issue with existing Event Hubs settings
    - [Root Cause] Bicep doesn't allow to assign the same resource to multiple template instances, so the deployment would failed if the existing Event Hub namespace or the existing Event Hub instance is the same for activity log and entra ID log. 
    - [Solution] Avoid to initialize the instances for Entra ID log if the existing Event Hub namespace/instance is as same as activity log 
3. Fix Bicep warnings
4. Correct the Falcon API permission scope info in `Update-Registration.ps1` and `README.md`
5. Fix the total length restriction of input parameters `resourceNamePrefix` and `resourceNameSuffix`. It should be 10 characters in total.