### PR TITLE
added github codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners
+* @CrowdStrike/fcs-engineering


### PR DESCRIPTION
Add GitHub CODEOWNERS file to designate FCS Engineering team as code owners for all repository files